### PR TITLE
FIXED:invalid minor version number of MySQL

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y perl --no-install-recommends && rm -rf 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 
 ENV MYSQL_MAJOR 5.6
-ENV MYSQL_VERSION 5.6.27-1debian8
+ENV MYSQL_VERSION 5.6.32-1debian8
 
 RUN echo "deb http://repo.mysql.com/apt/debian/ jessie mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 


### PR DESCRIPTION
downgrade from MYSQL_VERSION 5.6.27-1debian8 to MYSQL_VERSION 5.6.32-1debian8 try to fix up the issue #2.
